### PR TITLE
Prepare anorm docs scala3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -29,7 +29,7 @@ val common = Seq(
       case _             => Seq.empty
     }),
   javacOptions ++= Seq("-encoding", "UTF-8", "-Xlint:-options"),
-)
+) ++ Header.settings
 
 lazy val acolyteVersion = "1.2.9"
 lazy val acolyte        = "org.eu.acolyte" %% "jdbc-scala" % acolyteVersion % Test

--- a/core/src/main/scala-2/anorm/macros/ImplicitResolver.scala
+++ b/core/src/main/scala-2/anorm/macros/ImplicitResolver.scala
@@ -61,10 +61,10 @@ object ImplicitResolver {
           replacement: Type,
           altered: Boolean
       ): (Type, Boolean) = in match {
-        case tpe :: ts =>
-          boundTypes.getOrElse(tpe.typeSymbol.fullName, tpe) match {
+        case innerTpe :: ts =>
+          boundTypes.getOrElse(innerTpe.typeSymbol.fullName, innerTpe) match {
             case t if filter(t) =>
-              refactor(ts, base, replacement :: out, tail, filter, replacement, true)
+              refactor(ts, base, replacement :: out, tail, filter, replacement, altered = true)
 
             case TypeRef(_, sym, as) if as.nonEmpty =>
               refactor(as, sym.asType, List.empty, (ts, base, out) :: tail, filter, replacement, altered)
@@ -94,7 +94,7 @@ object ImplicitResolver {
             PlaceholderType -> true
 
           case TypeRef(_, sym, args) if args.nonEmpty =>
-            refactor(args, sym.asType, List.empty, List.empty, _ =:= tpe, PlaceholderType, false)
+            refactor(args, sym.asType, List.empty, List.empty, _ =:= tpe, PlaceholderType, altered = false)
 
           case t => t -> false
         }
@@ -104,7 +104,7 @@ object ImplicitResolver {
         case PlaceholderType => tpe
 
         case TypeRef(_, sym, args) =>
-          refactor(args, sym.asType, List.empty, List.empty, _ == PlaceholderType, tpe, false)._1
+          refactor(args, sym.asType, List.empty, List.empty, _ == PlaceholderType, tpe, altered = false)._1
 
         case _ => ptype
       }

--- a/core/src/main/scala/anorm/Anorm.scala
+++ b/core/src/main/scala/anorm/Anorm.scala
@@ -148,7 +148,7 @@ private[anorm] trait Sql extends WithResult {
   @SuppressWarnings(Array("TryGet" /* TODO: Make it safer */ ))
   def executeInsert[A](generatedKeysParser: ResultSetParser[A] = SqlParser.scalar[Long].singleOpt)(implicit
       connection: Connection
-  ): A = execInsert[A](preparedStatement(_, true), generatedKeysParser, ColumnAliaser.empty).get
+  ): A = execInsert[A](preparedStatement(_, getGeneratedKeys = true), generatedKeysParser, ColumnAliaser.empty).get
 
   /**
    * Executes this SQL as an insert statement.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -98,18 +98,7 @@ object Common extends AutoPlugin {
     scalacOptions ~= (_.filterNot(_ == "-Xfatal-warnings")),
     Test / fork           := true,
     mimaPreviousArtifacts := previousVersion.map(organization.value %% moduleName.value % _).toSet,
-    headerLicense := Some(
-      HeaderLicense.Custom(
-        "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>"
-      )
-    ),
-    headerMappings ++= Map(
-      FileType("sbt")        -> HeaderCommentStyle.cppStyleLineComment,
-      FileType("properties") -> HeaderCommentStyle.hashLineComment,
-      FileType.xml           -> HeaderCommentStyle.xmlStyleBlockComment,
-      FileType("md") -> CommentStyle(new LineCommentCreator("<!---", "-->"), commentBetween("<!---", "*", "-->"))
-    ),
-  ) ++ Publish.settings
+  ) ++ Header.settings ++ Publish.settings
 
   @inline def missMeth(n: String) =
     ProblemFilters.exclude[MissingMethodProblem](n)

--- a/project/Header.scala
+++ b/project/Header.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.HeaderPattern.commentBetween
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{
+  HeaderCommentStyle,
+  HeaderLicense,
+  headerLicense,
+  headerMappings
+}
+import de.heikoseeberger.sbtheader.{ CommentStyle, FileType, LineCommentCreator }
+
+object Header {
+  lazy val settings = Seq(
+    headerLicense := Some(
+      HeaderLicense.Custom(
+        "Copyright (C) from 2022 The Play Framework Contributors <https://github.com/playframework>, 2011-2021 Lightbend Inc. <https://www.lightbend.com>"
+      )
+    ),
+    headerMappings ++= Map(
+      FileType("sbt")        -> HeaderCommentStyle.cppStyleLineComment,
+      FileType("properties") -> HeaderCommentStyle.hashLineComment,
+      FileType.xml           -> HeaderCommentStyle.xmlStyleBlockComment,
+      FileType("md") -> CommentStyle(new LineCommentCreator("<!---", "-->"), commentBetween("<!---", "*", "-->"))
+    )
+  )
+}


### PR DESCRIPTION
This is a fork of the PR mkurz:prepare-anorm-docs-scala3. The purpose of the PR is to fix the compilation errors which occurred with scala 3. Whilst the code is compiling, there are still some deprecation warnings which have not been addressed. 
